### PR TITLE
[TEAM15-622] fix(ai): 레시피 추천 요청 시 이전에 입력한 재료의 데이터가 남아 있는 문제 해결

### DIFF
--- a/src/app/(with-layout)/(no-header)/recipe/ai/page.tsx
+++ b/src/app/(with-layout)/(no-header)/recipe/ai/page.tsx
@@ -62,6 +62,7 @@ const Page = () => {
             return;
         }
 
+        localStorage.removeItem("availableIngredients");
         sessionStorage.setItem("option_params", JSON.stringify(selectedOptions));
 
         const fetchMenus = async () => {


### PR DESCRIPTION
## resolve [TEAM15-622](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/GSotT947Pwkq128QJ5Noy)
## resolve #51

## 작업내용
- 새로운 파라미터를 통한 메뉴 요청 시 Local Storage 데이터를 초기화하도록 수정
