### PR TITLE
[TEAM15-632] feat(ai): 추천 레시피 페이지에서 북마크 추가 시 레시피 추천 스트리밍이 끝나지 않은 경우 기본 엔드포인트로 저장 요청을 전송하도록 변경

### DIFF
--- a/src/app/(with-layout)/(no-header)/recipe/ai/[name]/_source/components/RecipeStreaming.tsx
+++ b/src/app/(with-layout)/(no-header)/recipe/ai/[name]/_source/components/RecipeStreaming.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
-import React, {useEffect, useRef, useState} from "react";
+import React, {useEffect, useRef} from "react";
 import {
     AiRecipeRequestPayload,
     RecipeOptions,
@@ -20,6 +20,8 @@ interface Props {
     calories: number | undefined;
     recipeIntroduction: string;
     setRecipeIntroduction: React.Dispatch<React.SetStateAction<string>>;
+    isStreaming: boolean;
+    setIsStreaming: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const RecipeStreaming = ({
@@ -29,8 +31,9 @@ const RecipeStreaming = ({
                              calories,
                              recipeIntroduction,
                              setRecipeIntroduction,
+                             isStreaming,
+                             setIsStreaming
                          }: Props) => {
-    const [isStreaming, setIsStreaming] = useState<boolean>(false);
     const abortControllerRef = useRef<AbortController | null>(null);
 
     useEffect(() => {

--- a/src/app/(with-layout)/(no-header)/recipe/ai/[name]/page.tsx
+++ b/src/app/(with-layout)/(no-header)/recipe/ai/[name]/page.tsx
@@ -8,6 +8,7 @@ import {useEffect, useRef, useState} from "react";
 import {MdOutlineAccessTimeFilled} from "react-icons/md";
 import {FaFire} from "react-icons/fa6";
 import {
+    AddBookmarkRequestPayload,
     AddDetailedBookmarkRequestPayload,
     AiDetailedMenusRequestPayload,
     DetailedMenuOptions,
@@ -72,6 +73,7 @@ const Page = () => {
 
     const [isBookmarked, setIsBookmarked] = useState(sessionStorage.getItem(`isBookmarked_${recipeName}`) === "true");
     const {setMessage, setIsOpen} = useAlertStore();
+    const [isStreaming, setIsStreaming] = useState<boolean>(false);
 
     const handleClickBookmark = async () => {
         setIsBookmarked(!isBookmarked);
@@ -84,6 +86,20 @@ const Page = () => {
         if (!isBookmarked) {
             setMessage("북마크에 추가되었습니다.");
             setIsOpen(true);
+
+            if (!oneLineIntroduction || isStreaming) {
+                const payload: AddBookmarkRequestPayload = {
+                    name: recipeName,
+                    imageUrl: representativeImageUrl,
+                    cookingTime: cookingTime,
+                    calories: calories,
+                };
+
+                sessionStorage.setItem(`isBookmarked_${recipeName}`, "true");
+                await postBookmark(payload);
+
+                return;
+            }
 
             const payload: AddDetailedBookmarkRequestPayload = {
                 name: recipeName,
@@ -288,6 +304,8 @@ const Page = () => {
                                 calories={calories}
                                 recipeIntroduction={recipeIntroduction}
                                 setRecipeIntroduction={setRecipeIntroduction}
+                                isStreaming={isStreaming}
+                                setIsStreaming={setIsStreaming}
                             />
                         </div>
                     )}


### PR DESCRIPTION
## resolve [TEAM15-632](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/q5mrAJkQXSqc4NnfV7NNd)
## resolve #57

## 작업내용
- 스트리밍 완료 여부를 부모 컴포넌트인 page 컴포넌트에서 관리하도록 변경
- 스트리밍이 끝나지 않은 경우 기본 메뉴 정보만 저장하도록 변경